### PR TITLE
Rename breakpoints

### DIFF
--- a/assets/scss/supporting/variables-bootstrap-genesis.scss
+++ b/assets/scss/supporting/variables-bootstrap-genesis.scss
@@ -197,13 +197,13 @@ $paragraph-margin-bottom: 1em;
 // adapting to different screen sizes, for use in media queries.
 
 $grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px,
-  xxl: 1500px, // new
-  xxxl: 1921px // new
+  xxs: 0,
+  xs: 576px,
+  sm: 768px,
+  md: 992px,
+  lg: 1200px,
+  xl: 1500px, // new
+  xxl: 1921px // new
 );
 
 
@@ -212,12 +212,12 @@ $grid-breakpoints: (
 // Define the maximum width of `.container` for different screen sizes.
 
 $container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px,
-  xxl: 1440px, // new
-  xxxl: 1860px // new
+  xs: 540px,
+  sm: 720px,
+  md: 960px,
+  lg: 1140px,
+  xl: 1440px, // new
+  xxl: 1860px // new
 );
 
 


### PR DESCRIPTION
Bootstrap 4 introduced a new breakpoint at 576, shifting the old names up by one step. Renaming these will allow for columns in legacy HTML to still function as intended.