### PR TITLE
Remove manual RFS import and set the RFS option variable to true

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,9 +1,6 @@
 // Bootstrap Core Variable Override
 @import "supporting/variables-bootstrap-core-override";
 
-// Import Responsive Font-Size, since Bootstrap seems to not do so
-@import "../../node_modules/bootstrap/scss/vendor/_rfs.scss";
-
 // Bootstrap Genesis Theme Variables
 @import "supporting/variables-bootstrap-genesis";
 

--- a/assets/scss/supporting/variables-bootstrap-genesis.scss
+++ b/assets/scss/supporting/variables-bootstrap-genesis.scss
@@ -242,6 +242,24 @@ $font-weight-heavy: 900;
 $font-weight-base: $font-weight-light;
 
 
+// Options
+//
+// Quickly modify global styling by enabling or disabling optional features.
+
+//$enable-caret: true;
+//$enable-rounded: true;
+//$enable-shadows: false;
+//$enable-gradients: false;
+//$enable-transitions: true;
+//$enable-prefers-reduced-motion-media-query: true;
+//$enable-grid-classes: true !default;
+//$enable-pointer-cursor-for-buttons: true;
+//$enable-print-styles: true;
+$enable-responsive-font-sizes: true;
+//$enable-validation-icons: true;
+//$enable-deprecation-messages: true;
+
+
 
 $galleryCaptionColor: $figure-caption-color;
 


### PR DESCRIPTION
After actually _reading_ the [bootstrap documentation](https://getbootstrap.com/docs/4.3/content/typography/#responsive-font-sizes), I learned that this was the correct way to enable responsive font sizes. I pulled all the other option variables into our variables file, too, but commented them out.